### PR TITLE
fix: manifest credentials bug in chrome

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
         <meta name="msapplication-config" content="browserconfig.xml" />
 
         <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-        <link rel="manifest" href="%PUBLIC_URL%/manifest.webapp" />
+        <link rel="manifest" href="%PUBLIC_URL%/manifest.webapp" crossorigin="use-credentials" />
         <link
             rel="apple-touch-icon"
             sizes="180x180"


### PR DESCRIPTION
See https://jira.dhis2.org/browse/DHIS2-6122.

From my comment in the Jira-issue: 
> This bug only seem to affect Chrome. The reason is that chrome does not seem to send credential-headers or cookies for 'rel=manifest' attributes on the link-tag, even for same origin requests. This means that the server responds with a 302-redirect to the login-page, and the browser tries to parse this as JSON, which fails since its html (the login page).
The solution is to add the attribute `crossorigin='use-credentials'`/ to the manifest-link-tag.
See https://github.com/w3c/manifest/issues/186#issuecomment-43939505 and https://github.com/w3c/manifest/issues/535#issuecomment-435739223 for discussion about this weird behaviour.
