### PR TITLE
fix(select): adjust from string based props to boolean props

### DIFF
--- a/src/components/FilterFields/__snapshots__/dropDownComponents.test.js.snap
+++ b/src/components/FilterFields/__snapshots__/dropDownComponents.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`dropDownComponents <AggregationLevel/> matches the snapshot 1`] = `
 <ComponentWithMargin
-  kind="filled"
+  filled={true}
   label="Aggregation Level"
   name="aggregationLevel"
   onChange={[MockFunction]}
@@ -23,7 +23,7 @@ exports[`dropDownComponents <AggregationLevel/> matches the snapshot 1`] = `
 
 exports[`dropDownComponents <Category/> matches the snapshot 1`] = `
 <ComponentWithMargin
-  kind="filled"
+  filled={true}
   label="Category"
   name="category"
   onChange={[MockFunction]}
@@ -59,7 +59,7 @@ exports[`dropDownComponents <Category/> matches the snapshot 1`] = `
 
 exports[`dropDownComponents <ChartType/> matches the snapshot 1`] = `
 <ComponentWithMargin
-  kind="filled"
+  filled={true}
   label="Chart Type"
   name="chartType"
   onChange={[MockFunction]}
@@ -80,7 +80,7 @@ exports[`dropDownComponents <ChartType/> matches the snapshot 1`] = `
 
 exports[`dropDownComponents <EventType/> matches the snapshot 1`] = `
 <ComponentWithMargin
-  kind="filled"
+  filled={true}
   label="Event Type"
   name="eventType"
   onChange={[MockFunction]}
@@ -126,7 +126,7 @@ exports[`dropDownComponents <EventType/> matches the snapshot 1`] = `
 
 exports[`dropDownComponents <Interval/> matches the snapshot 1`] = `
 <ComponentWithMargin
-  kind="filled"
+  filled={true}
   label="Interval"
   name="interval"
   onChange={[MockFunction]}
@@ -157,7 +157,7 @@ exports[`dropDownComponents <Interval/> matches the snapshot 1`] = `
 
 exports[`dropDownComponents <PageSize/> matches the snapshot 1`] = `
 <ComponentWithMargin
-  kind="filled"
+  filled={true}
   label="Page Size"
   name="pageSize"
   onChange={[MockFunction]}
@@ -193,7 +193,7 @@ exports[`dropDownComponents <PageSize/> matches the snapshot 1`] = `
 
 exports[`dropDownComponents <SortOrder/> matches the snapshot 1`] = `
 <ComponentWithMargin
-  kind="filled"
+  filled={true}
   label="Sort Order"
   name="sortOrder"
   onChange={[MockFunction]}

--- a/src/components/FilterFields/dropDownComponents.js
+++ b/src/components/FilterFields/dropDownComponents.js
@@ -13,11 +13,12 @@ import SORT_ORDERS from '../../constants/sortOrders'
 
 const FIELD_KIND = 'filled'
 
+const withKind = props => ({ ...props, [FIELD_KIND]: true })
 const SelectFieldWithMargin = withMargin(SelectField)
 
 export const Category = props => (
     <SelectFieldWithMargin
-        {...props}
+        {...withKind(props)}
         name="category"
         label={i18n.t('Category')}
         kind={FIELD_KIND}
@@ -30,7 +31,7 @@ export const Category = props => (
 
 export const Interval = props => (
     <SelectFieldWithMargin
-        {...props}
+        {...withKind(props)}
         name="interval"
         label={i18n.t('Interval')}
         kind={FIELD_KIND}
@@ -43,7 +44,7 @@ export const Interval = props => (
 
 export const AggregationLevel = props => (
     <SelectFieldWithMargin
-        {...props}
+        {...withKind(props)}
         name="aggregationLevel"
         label={i18n.t('Aggregation Level')}
         kind={FIELD_KIND}
@@ -56,7 +57,7 @@ export const AggregationLevel = props => (
 
 export const ChartType = props => (
     <SelectFieldWithMargin
-        {...props}
+        {...withKind(props)}
         name="chartType"
         label={i18n.t('Chart Type')}
         kind={FIELD_KIND}
@@ -69,7 +70,7 @@ export const ChartType = props => (
 
 export const EventType = props => (
     <SelectFieldWithMargin
-        {...props}
+        {...withKind(props)}
         name="eventType"
         label={i18n.t('Event Type')}
         kind={FIELD_KIND}
@@ -82,7 +83,7 @@ export const EventType = props => (
 
 export const PageSize = props => (
     <SelectFieldWithMargin
-        {...props}
+        {...withKind(props)}
         name="pageSize"
         label={i18n.t('Page Size')}
         kind={FIELD_KIND}
@@ -95,7 +96,7 @@ export const PageSize = props => (
 
 export const SortOrder = props => (
     <SelectFieldWithMargin
-        {...props}
+        {...withKind(props)}
         name="sortOrder"
         label={i18n.t('Sort Order')}
         kind={FIELD_KIND}

--- a/src/components/FilterFields/dropDownComponents.js
+++ b/src/components/FilterFields/dropDownComponents.js
@@ -21,7 +21,6 @@ export const Category = props => (
         {...withKind(props)}
         name="category"
         label={i18n.t('Category')}
-        kind={FIELD_KIND}
     >
         {CATEGORIES.map(i => (
             <option value={i.value}>{i.label}</option>
@@ -34,7 +33,6 @@ export const Interval = props => (
         {...withKind(props)}
         name="interval"
         label={i18n.t('Interval')}
-        kind={FIELD_KIND}
     >
         {INTERVALS.map(i => (
             <option value={i.value}>{i.label}</option>
@@ -47,7 +45,6 @@ export const AggregationLevel = props => (
         {...withKind(props)}
         name="aggregationLevel"
         label={i18n.t('Aggregation Level')}
-        kind={FIELD_KIND}
     >
         {AGGREGATIONS.map(i => (
             <option value={i.value}>{i.label}</option>
@@ -60,7 +57,6 @@ export const ChartType = props => (
         {...withKind(props)}
         name="chartType"
         label={i18n.t('Chart Type')}
-        kind={FIELD_KIND}
     >
         {CHART_TYPES.map(i => (
             <option value={i.value}>{i.label}</option>
@@ -73,7 +69,6 @@ export const EventType = props => (
         {...withKind(props)}
         name="eventType"
         label={i18n.t('Event Type')}
-        kind={FIELD_KIND}
     >
         {EVENT_TYPES.map(i => (
             <option value={i.value}>{i.label}</option>
@@ -86,7 +81,6 @@ export const PageSize = props => (
         {...withKind(props)}
         name="pageSize"
         label={i18n.t('Page Size')}
-        kind={FIELD_KIND}
     >
         {PAGE_SIZES.map(i => (
             <option value={i.value}>{i.label}</option>
@@ -99,7 +93,6 @@ export const SortOrder = props => (
         {...withKind(props)}
         name="sortOrder"
         label={i18n.t('Sort Order')}
-        kind={FIELD_KIND}
     >
         {SORT_ORDERS.map(i => (
             <option value={i.value}>{i.label}</option>


### PR DESCRIPTION
We were using the "filled" Select components from ui-core. However, in the new version the API changed a little bit. Now the prop should be declared as `filled` or `filled={true}`. Previously this was `kind="filled"`.