### PR TITLE
chore: fix deploy-build (deploy from build/app)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
     - npm run build
 deploy:
     - provider: script
-      script: npx --package @dhis2/deploy-build deploy-build
+      script: npx --package @dhis2/deploy-build deploy-build app
       skip_cleanup: true
       on:
           all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
     - npm run build
 deploy:
     - provider: script
-      script: npx --package @dhis2/deploy-build deploy-build app
+      script: npx --package @dhis2/deploy-build deploy-build d2-ci build/app
       skip_cleanup: true
       on:
           all_branches: true


### PR DESCRIPTION
Before this change, the entire `build` dir (which is **not** the built application) was pushed to [`d2-ci`](https://github.com/d2-ci/usage-analytics-app).  This should only publish the `build/app` directory instead (passing $COMPONENT) to `deploy-build`

Requires dhis2/deploy-build#12