### PR TITLE
fix: ensure update-filter gets called with the proper arguments

### DIFF
--- a/src/components/FilterFields/index.js
+++ b/src/components/FilterFields/index.js
@@ -25,12 +25,12 @@ export const IntervalDropDown = connect(
 
 export const AggregationLevelDropDown = connect(
     createValueGetterForFilterKey('aggregationLevel'),
-    { onChange: updateFilter }
+    { onChange: e => updateFilter(e.target.name, e.target.value) }
 )(DropDowns.AggregationLevel)
 
 export const ChartTypeDropDown = connect(
     createValueGetterForFilterKey('chartType'),
-    { onChange: updateFilter }
+    { onChange: e => updateFilter(e.target.name, e.target.value) }
 )(DropDowns.ChartType)
 
 export const EventTypeDropDown = connect(


### PR DESCRIPTION
`updateFilter` was being called with the event, whereas it expects a key and value. Which is why it broke, as ui-core went from calling onChange with e.target.name and e.target.value, to calling it with the event, which I didn't catch during the upgrade. 

I could refactor it to just accept an event, like the other actions, but not having the action deal with the event directly seems more clear to me. Plus `updateFilter` is being called directly with `key, value` in other locations, so it seems the least invasive to fix it like this.