### PR TITLE
fix: render error message on missing date

### DIFF
--- a/src/components/FilterFields/DateRange.js
+++ b/src/components/FilterFields/DateRange.js
@@ -7,6 +7,7 @@ import './DateRange.css'
 export const START_DATE = 'startDate'
 export const END_DATE = 'endDate'
 export const ERROR_PATTERN = i18n.t('Please use the format yyyy-mm-dd')
+export const ERROR_MISSING_DATE = i18n.t('Please fill in both dates')
 export const ERROR_END_BEFORE_START = i18n.t('End date is before start date')
 export const ERROR_START_AFTER_END = i18n.t('Start date is after end date')
 
@@ -57,6 +58,10 @@ class DateRange extends Component {
     getError(dateRange, key) {
         if (!/[0-9]{4}-[0-9]{2}-[0-9]{2}/.test(dateRange[key])) {
             return ERROR_PATTERN
+        }
+
+        if (!dateRange.startDate || !dateRange.endDate) {
+            return ERROR_MISSING_DATE
         }
 
         if (dateRange.endDate < dateRange.startDate) {

--- a/src/components/FilterFields/DateRange.test.js
+++ b/src/components/FilterFields/DateRange.test.js
@@ -4,6 +4,7 @@ import DateRange, {
     START_DATE,
     END_DATE,
     ERROR_PATTERN,
+    ERROR_MISSING_DATE,
     ERROR_START_AFTER_END,
     ERROR_END_BEFORE_START,
 } from './DateRange'
@@ -65,6 +66,20 @@ describe('<DateRange/>', () => {
         expect(
             wrapper.find(`span.uaa-date-input-error.${START_DATE}`)
         ).toHaveText(ERROR_PATTERN)
+    })
+    it('renders a missing date error when startDate changes into a valid value but endDate is empty', () => {
+        const defaultProps = {
+            updateFilter,
+            updateUsageData,
+        }
+        const wrapper = shallow(<DateRange {...defaultProps} />)
+        const startDateInput = wrapper.find(`.${START_DATE}`)
+
+        startDateInput.simulate('change', { target: { value: '2019-12-30' } })
+
+        expect(
+            wrapper.find(`span.uaa-date-input-error.${START_DATE}`)
+        ).toHaveText(ERROR_MISSING_DATE)
     })
     it('renders a start-after-end error when start date become greater than end date', () => {
         const value = '2020-01-01'


### PR DESCRIPTION
This fixes a bug where the daterange component was already firing off a get when one of the dates was still empty.

For the test I needed the component with both dates null, to simulate an empty daterange with one of the dates changing to a valid date. So I've not reused the existing wrapper that the other tests use. I've not seen a wrapper been reused between tests like this, I'm not sure if this might cause the tests to share state and become unreliable. So to be safe I've isolated this test. We might consider doing this for the other tests as well.