### PR TITLE
fix: prevent double scrollbars on linux

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,6 @@
 body {
     margin: 0;
     padding: 0;
-    overflow-y: scroll;
 }
 
 .uaa-container {


### PR DESCRIPTION
I could only reproduce this issue in Chrome on Ubuntu. MacOS was unaffected. Removing the overflow-y changes the UI slightly because now the scrollbar is not always there anymore.

You might wonder why that rule was there in the first place. I am not 100% sure anymore, but I seem to remember that there used to be some issue with `react-chartjs-2` that caused the graph to redraw very slowly when the container was resized (i.e. if a scrollbar was added to the page causing the width to decrease). This issue seems to have been fixed though, so removing this style is a good thing.