### PR TITLE
fix(i18n): import from `locales/index.js` in root to add translations

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -76,6 +76,9 @@ jobs:
                   path: '**/node_modules'
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
+            - name: Generate translations
+              run: yarn d2-app-scripts i18n generate
+
             - name: Lint
               run: yarn lint
 

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -98,6 +98,9 @@ jobs:
                   path: '**/node_modules'
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
+            - name: Generate translations
+              run: yarn d2-app-scripts i18n generate
+
             - name: Test
               run: yarn test
 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { CssVariables } from '@dhis2/ui'
+import '../../locales/index.js'
 import { FAVORITE_VIEWS } from '../../constants/categories.js'
 import { WEEK } from '../../constants/intervals.js'
 import { SUM } from '../../constants/aggregations.js'


### PR DESCRIPTION
In `./locales/index.js` we add all the translation resources, but we never imported from that file so this code never ran. And the result was missing translations and the defualt strings being used.