### PR TITLE
feat: include passive views when necessary

### DIFF
--- a/src/components/Queries/DataStatisticsQuery.js
+++ b/src/components/Queries/DataStatisticsQuery.js
@@ -20,6 +20,12 @@ const query = {
             fields,
         }),
     },
+    systemSettings: {
+        resource: 'systemSettings',
+        params: {
+            key: 'keyCountPassiveDashboardViewsInUsageAnalytics',
+        },
+    },
 }
 
 const DataStatisticsQuery = ({
@@ -77,6 +83,19 @@ const DataStatisticsQuery = ({
                 {error.message ? message : fallback}
             </NoticeBox>
         )
+    }
+
+    const {
+        keyCountPassiveDashboardViewsInUsageAnalytics: countPassiveViews,
+    } = data.systemSettings
+
+    // If passive views should be counted, mutate the data to include passive views in the totals
+    if (countPassiveViews) {
+        data.dataStatistics.forEach(statistic => {
+            statistic.dashboardViews += statistic.passiveDashboardViews
+            statistic.averageDashboardViews =
+                statistic.dashboardViews / statistic.users
+        })
     }
 
     return children(data.dataStatistics)

--- a/src/components/Queries/DataStatisticsQuery.test.js
+++ b/src/components/Queries/DataStatisticsQuery.test.js
@@ -214,9 +214,59 @@ describe('<DataStatisticsQuery>', () => {
     })
 
     describe('receiving data', () => {
-        it('calls children with the received data', async () => {
+        it('calls children with the received data when count passive views is false', async () => {
             const expected = 'Expected data'
-            const data = { dataStatistics: expected }
+            const data = {
+                dataStatistics: expected,
+                systemSettings: {
+                    keyCountPassiveDashboardViewsInUsageAnalytics: false,
+                },
+            }
+            const spy = jest.fn(() => null)
+            const props = {
+                children: spy,
+                endDate: '2020-01-01',
+                fields: ['*'],
+                interval: YEAR,
+                isIntervalStale: false,
+                setIsIntervalStale: () => {},
+                startDate: '2010-01-01',
+            }
+
+            const wrapper = mount(
+                <CustomDataProvider data={data}>
+                    <DataStatisticsQuery {...props} />
+                </CustomDataProvider>
+            )
+
+            await act(update(wrapper))
+            await waitForExpect(() => {
+                expect(spy).toHaveBeenCalledWith(expected)
+            })
+        })
+
+        it('calls children with the received data when count passive views is true', async () => {
+            const expected = [
+                {
+                    dashboardViews: 1000,
+                    passiveDashboardViews: 900,
+                    averageDashboardViews: 100,
+                    users: 10,
+                },
+            ]
+            const data = {
+                dataStatistics: [
+                    {
+                        dashboardViews: 100,
+                        passiveDashboardViews: 900,
+                        averageDashboardViews: 10,
+                        users: 10,
+                    },
+                ],
+                systemSettings: {
+                    keyCountPassiveDashboardViewsInUsageAnalytics: true,
+                },
+            }
             const spy = jest.fn(() => null)
             const props = {
                 children: spy,
@@ -242,7 +292,12 @@ describe('<DataStatisticsQuery>', () => {
 
         it('calls setIsIntervalStale with false when data has been received', async () => {
             const expected = 'Expected data'
-            const data = { dataStatistics: expected }
+            const data = {
+                dataStatistics: expected,
+                systemSettings: {
+                    keyCountPassiveDashboardViewsInUsageAnalytics: false,
+                },
+            }
             const children = jest.fn(() => null)
             const setIsIntervalStale = jest.fn()
             const props = {

--- a/src/components/Queries/TopFavoritesQuery.test.js
+++ b/src/components/Queries/TopFavoritesQuery.test.js
@@ -1,30 +1,28 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import { CustomDataProvider } from '@dhis2/app-runtime'
-import { act } from 'react-dom/test-utils'
-import waitForExpect from 'wait-for-expect'
+import { useDataQuery } from '@dhis2/app-runtime'
 import TopFavoritesQuery from './TopFavoritesQuery.js'
+import { DASHBOARD_VIEW } from '../../constants/eventTypes.js'
 
 /**
- * This allows react to update the wrapper after the async app runtime logic has
- * done its thing and updated state.
- *
- * - https://dev.to/dannypule/fix-the-not-wrapped-in-act-warning-simple-solution-3lj1
- * - https://reactjs.org/docs/testing-recipes.html#act
+ * We're mocking the app-runtime here instead of using the CustomDataProvider, since
+ * the CustomDataProvider doesn't work for queries that call the same endpoint more
+ * than once.
  */
 
-const update = wrapper => () =>
-    new Promise(resolve => {
-        setImmediate(() => {
-            wrapper.update()
-            resolve()
-        })
-    })
+jest.mock('@dhis2/app-runtime', () => ({
+    useDataQuery: jest.fn(),
+}))
 
 describe('<TopFavoritesQuery>', () => {
     describe('rendering a spinner', () => {
         it('renders a spinner when loading', async () => {
-            const data = { 'dataStatistics/favorites': 'data' }
+            useDataQuery.mockImplementation(() => ({
+                loading: true,
+                called: true,
+                refetch: () => {},
+            }))
+
             const props = {
                 children: () => null,
                 fields: ['*'],
@@ -33,13 +31,7 @@ describe('<TopFavoritesQuery>', () => {
                 sortOrder: '',
             }
 
-            const wrapper = mount(
-                <CustomDataProvider data={data} options={{ loadForever: true }}>
-                    <TopFavoritesQuery {...props} />
-                </CustomDataProvider>
-            )
-
-            await act(update(wrapper))
+            const wrapper = mount(<TopFavoritesQuery {...props} />)
 
             expect(wrapper.exists({ role: 'progressbar' })).toBe(true)
         })
@@ -47,16 +39,18 @@ describe('<TopFavoritesQuery>', () => {
 
     describe('errors', () => {
         it('displays errors it encounters', async () => {
+            useDataQuery.mockImplementation(() => ({
+                loading: false,
+                called: true,
+                error: new Error('Error'),
+                refetch: () => {},
+            }))
+
             const titleSelector = {
                 'data-test': 'dhis2-uicore-noticebox-title',
             }
             const messageSelector = {
                 'data-test': 'dhis2-uicore-noticebox-message',
-            }
-            const data = {
-                'dataStatistics/favorites': () => {
-                    throw new Error('Error')
-                },
             }
             const props = {
                 children: () => {},
@@ -66,33 +60,28 @@ describe('<TopFavoritesQuery>', () => {
                 sortOrder: '',
             }
 
-            const wrapper = mount(
-                <CustomDataProvider data={data}>
-                    <TopFavoritesQuery {...props} />
-                </CustomDataProvider>
-            )
+            const wrapper = mount(<TopFavoritesQuery {...props} />)
 
-            await act(update(wrapper))
-            await waitForExpect(() => {
-                const title = wrapper.find(titleSelector)
-                const message = wrapper.find(messageSelector)
+            const title = wrapper.find(titleSelector)
+            const message = wrapper.find(messageSelector)
 
-                expect(title.text()).toBe('Error whilst fetching data')
-                expect(message.text()).toBe('The error message was: "Error".')
-            })
+            expect(title.text()).toBe('Error whilst fetching data')
+            expect(message.text()).toBe('The error message was: "Error".')
         })
 
         it('renders a fallback message for errors', async () => {
+            useDataQuery.mockImplementation(() => ({
+                loading: false,
+                called: true,
+                error: new Error(),
+                refetch: () => {},
+            }))
+
             const titleSelector = {
                 'data-test': 'dhis2-uicore-noticebox-title',
             }
             const messageSelector = {
                 'data-test': 'dhis2-uicore-noticebox-message',
-            }
-            const data = {
-                'dataStatistics/favorites': () => {
-                    throw new Error()
-                },
             }
             const props = {
                 children: () => {},
@@ -102,29 +91,36 @@ describe('<TopFavoritesQuery>', () => {
                 sortOrder: '',
             }
 
-            const wrapper = mount(
-                <CustomDataProvider data={data}>
-                    <TopFavoritesQuery {...props} />
-                </CustomDataProvider>
+            const wrapper = mount(<TopFavoritesQuery {...props} />)
+
+            const title = wrapper.find(titleSelector)
+            const message = wrapper.find(messageSelector)
+
+            expect(title.text()).toBe('Error whilst fetching data')
+            expect(message.text()).toBe(
+                'There was no error message included with the error.'
             )
-
-            await act(update(wrapper))
-            await waitForExpect(() => {
-                const title = wrapper.find(titleSelector)
-                const message = wrapper.find(messageSelector)
-
-                expect(title.text()).toBe('Error whilst fetching data')
-                expect(message.text()).toBe(
-                    'There was no error message included with the error.'
-                )
-            })
         })
     })
 
     describe('receiving data', () => {
-        it('calls children with the received data', async () => {
+        it('calls children with the expected data when count passive views is false', async () => {
             const expected = 'Expected data'
-            const data = { 'dataStatistics/favorites': expected }
+
+            useDataQuery.mockImplementation(() => ({
+                loading: false,
+                called: true,
+                error: undefined,
+                refetch: () => {},
+                data: {
+                    favorites: expected,
+                    passiveFavorites: [],
+                    systemSettings: {
+                        keyCountPassiveDashboardViewsInUsageAnalytics: false,
+                    },
+                },
+            }))
+
             const spy = jest.fn(() => null)
             const props = {
                 children: spy,
@@ -134,16 +130,55 @@ describe('<TopFavoritesQuery>', () => {
                 sortOrder: '',
             }
 
-            const wrapper = mount(
-                <CustomDataProvider data={data}>
-                    <TopFavoritesQuery {...props} />
-                </CustomDataProvider>
-            )
+            mount(<TopFavoritesQuery {...props} />)
 
-            await act(update(wrapper))
-            await waitForExpect(() => {
-                expect(spy).toHaveBeenCalledWith(expected)
-            })
+            expect(spy).toHaveBeenCalledWith(expected)
+        })
+
+        it('calls children with the expected data when count passive views is true and the event type is DASHBOARD_VIEW', async () => {
+            const expected = [
+                {
+                    id: 'id',
+                    views: 20,
+                },
+            ]
+
+            useDataQuery.mockImplementation(() => ({
+                loading: false,
+                called: true,
+                error: undefined,
+                refetch: () => {},
+                data: {
+                    favorites: [
+                        {
+                            id: 'id',
+                            views: 10,
+                        },
+                    ],
+                    passiveFavorites: [
+                        {
+                            id: 'id',
+                            views: 10,
+                        },
+                    ],
+                    systemSettings: {
+                        keyCountPassiveDashboardViewsInUsageAnalytics: true,
+                    },
+                },
+            }))
+
+            const spy = jest.fn(() => null)
+            const props = {
+                children: spy,
+                fields: ['*'],
+                eventType: DASHBOARD_VIEW,
+                pageSize: '',
+                sortOrder: '',
+            }
+
+            mount(<TopFavoritesQuery {...props} />)
+
+            expect(spy).toHaveBeenCalledWith(expected)
         })
     })
 })


### PR DESCRIPTION
Closes: https://jira.dhis2.org/browse/DHIS2-10589, closes #438 
Background info: https://jira.dhis2.org/browse/DHIS2-7016

- [x] Update tests
- [x] Verify it's working correctly against #438

Follow up:

- Bug: the customDataProvider hangs when mocking a query that contains duplicate endpoints