### PR TITLE
fix(query): map instead of mutating data query data

### DIFF
--- a/src/components/Queries/DataStatisticsQuery.js
+++ b/src/components/Queries/DataStatisticsQuery.js
@@ -86,19 +86,29 @@ const DataStatisticsQuery = ({
     }
 
     const {
-        keyCountPassiveDashboardViewsInUsageAnalytics: countPassiveViews,
-    } = data.systemSettings
+        systemSettings: {
+            keyCountPassiveDashboardViewsInUsageAnalytics: countPassiveViews,
+        },
+        dataStatistics,
+    } = data
 
-    // If passive views should be counted, mutate the data to include passive views in the totals
+    // If passive views should be counted, return statistics that include passive views in the totals
     if (countPassiveViews) {
-        data.dataStatistics.forEach(statistic => {
-            statistic.dashboardViews += statistic.passiveDashboardViews
-            statistic.averageDashboardViews =
-                statistic.dashboardViews / statistic.users
+        const withPassiveViews = dataStatistics.map(s => {
+            const dashboardViews = s.dashboardViews + s.passiveDashboardViews
+            const averageDashboardViews = dashboardViews / s.users
+
+            return {
+                ...s,
+                dashboardViews,
+                averageDashboardViews,
+            }
         })
+
+        return children(withPassiveViews)
     }
 
-    return children(data.dataStatistics)
+    return children(dataStatistics)
 }
 
 DataStatisticsQuery.propTypes = {

--- a/src/components/Queries/TopFavoritesQuery.js
+++ b/src/components/Queries/TopFavoritesQuery.js
@@ -86,12 +86,16 @@ const TopFavoritesQuery = ({
     }
 
     const {
-        keyCountPassiveDashboardViewsInUsageAnalytics: countPassiveViews,
-    } = data.systemSettings
+        systemSettings: {
+            keyCountPassiveDashboardViewsInUsageAnalytics: countPassiveViews,
+        },
+        passiveFavorites,
+        favorites,
+    } = data
 
-    // If passive views should be counted, add them to the view totals for dashboards
+    // If passive views should be counted, return statistics that include passive views in the totals
     if (countPassiveViews && eventType === DASHBOARD_VIEW) {
-        const passiveViewsById = data.passiveFavorites.reduce(
+        const passiveViewsById = passiveFavorites.reduce(
             (acc, passiveFavorite) => {
                 acc[passiveFavorite.id] = passiveFavorite.views
                 return acc
@@ -99,14 +103,21 @@ const TopFavoritesQuery = ({
             {}
         )
 
-        data.favorites.forEach(favorite => {
-            if (favorite.id in passiveViewsById) {
-                favorite.views += passiveViewsById[favorite.id]
+        const withPassiveViews = favorites.map(f => {
+            if (f.id in passiveViewsById) {
+                return {
+                    ...f,
+                    views: f.views + passiveViewsById[f.id],
+                }
             }
+
+            return f
         })
+
+        return children(withPassiveViews)
     }
 
-    return children(data.favorites)
+    return children(favorites)
 }
 
 TopFavoritesQuery.propTypes = {


### PR DESCRIPTION
In hindsight I'm not as comfortable mutating data returned by the data engine. I've tested with a large dataset, and for me mapping to a new array instead of mutating doesn't cause any noticeable slowdown. So I feel the more predictable nature of returning a new array is worth it.

The changes are covered by unit tests. I've also updated one of the tests to use the CustomDataProvider instead of mocking. I thought this test case wouldn't work with the CustomDataProvider, but turns out I just misunderstood how it worked. So I've fixed that test as well.