### PR TITLE
chore(release): prepare for continuous delivery

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -4,6 +4,8 @@ const config = {
     title: 'Usage Analytics',
     coreApp: true,
 
+    minDHIS2Version: '2.37',
+
     entryPoints: {
         app: './src/components/App/App.js',
     },


### PR DESCRIPTION
Add the 2.37 minimum DHIS2 version to d2.config.js.

BREAKING CHANGE: In preparation for continuous delivery we are bumping
all application versions to 100.0.0 to decouple them from DHIS2
versions.
