### PR TITLE
chore(release): migrate to new app version scheme

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -4,6 +4,9 @@ const config = {
     title: 'Usage Analytics',
     coreApp: true,
 
+    id: '',
+    minDHIS2Version: '2.37',
+
     entryPoints: {
         app: './src/components/App/App.js',
     },

--- a/d2.config.js
+++ b/d2.config.js
@@ -4,8 +4,8 @@ const config = {
     title: 'Usage Analytics',
     coreApp: true,
 
-    id: '',
-    minDHIS2Version: '2.37',
+    id: '7a243207-2de8-4620-b3e2-5162106284d4',
+    minDHIS2Version: '2.32',
 
     entryPoints: {
         app: './src/components/App/App.js',


### PR DESCRIPTION
Align all our application versions that range between 0.x.x and 36.x.x
with different semantics to a single version scheme with distinct
semantics for what constitutes a breaking change.

We have chosen to bump to v100.0.0 to signify the depature from the old
version scheme to the new.

For more information:
https://github.com/dhis2/notes/discussions/293

BREAKING CHANGE: App version becomes decoupled from DHIS2 versions, see
the d2.config.js or App Hub for DHIS2 version compatibility.
