### PR TITLE
docs: avoid the extra level of navigation

### DIFF
--- a/docs/user/index.yml
+++ b/docs/user/index.yml
@@ -1,1 +1,1 @@
-- Visualize usage statistics: 'visualize-usage-statistics.md'
+'visualize-usage-statistics.md'


### PR DESCRIPTION
The entire content of this file will replace the reference in the parent yaml file, so in order to directly replace a reference to a single file, we need to include only the file without any additional structure.