### PR TITLE
fix(app): ensure startDate and endDate params of dataStatistics endpoint are ASCII

### DIFF
--- a/src/components/App/createDefaultDates.js
+++ b/src/components/App/createDefaultDates.js
@@ -13,8 +13,12 @@ const createDefaultDates = () => {
     const now = Date.now()
     const format = 'YYYY-MM-DD'
 
-    const initialStartDate = moment(now).subtract(4, 'months').format(format)
-    const initialEndDate = moment(now).format(format)
+    // Set locale to English before formatting to ensure ASCII numbers are used
+    const initialStartDate = moment(now)
+        .locale('en')
+        .subtract(4, 'months')
+        .format(format)
+    const initialEndDate = moment(now).locale('en').format(format)
 
     return { initialStartDate, initialEndDate }
 }


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-12923

When a user has their locale set to Arabic, `moment().format('YYYY-MM-DD')` will return Arabic numbers (e.g. `٢٠٢١-١١-٢٢`). This PR fixes this issue by setting the local moment locale to `en` before formatting. The global moment locale is unaffected.